### PR TITLE
Allow Gremlin to operate with Jung libraries.

### DIFF
--- a/src/main/java/com/tinkerpop/gremlin/functions/jung/JungFunctions.java
+++ b/src/main/java/com/tinkerpop/gremlin/functions/jung/JungFunctions.java
@@ -10,8 +10,15 @@ public class JungFunctions extends AbstractFunctions {
     private static final String NAMESPACE = "jung";
 
     public JungFunctions() {
-        this.functions.add(new PageRankFunction());
-        this.functions.add(new DijkstraShortestPathFunction());
+        try
+        {
+            this.functions.add(new PageRankFunction());
+            this.functions.add(new DijkstraShortestPathFunction());
+        }
+        catch (NoClassDefFoundError ignore)
+        {
+            // If jung.jar is not provided, proceed without adding functions.
+        }
     }
 
     public String getNamespace() {


### PR DESCRIPTION
All the service providers except Jung (as far as I can tell) will lazily fail if their required jars are not present with the exception of Jung.  That is, if I don't provide the OrientDB jar, when Gremlin loads, the OrientDBFunctions constructor invokes a harmless OpenFunction:
    public OrientDBFunctions() {
        this.functions.add(new OpenFunction());
    }

However, the JungFunctions() constructor calls code that requires the Jung jar to be on the path or else an Exception is thrown.  The problem is that the Jung license has some restrictions in it (passed along from the license for the embedded colt classes), that would require our organization to pass along.  It's not that we would be in huge risk of violating the restriction, but the cost to our organization to put in place procedures that ensure that we do not violate the restriction would be prohibitive.  Here's the excerpt from the colt license: "...with the exception that any usage related to military applications is expressly forbidden."

I would like to propose wrapping the JungFunctions class in a try/ catch block so that we can get Jung to lazily fail like the other service providers.
