### PR TITLE
Patch to allow deployment to Maven central repo via Sonatype OSS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,12 @@
         This language has application in the areas of graph query, analysis, and manipulation.
     </description>
     <inceptionYear>2011</inceptionYear>
+    <licenses>
+        <license>
+            <name>BSD 3-Clause</name>
+            <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+        </license>
+    </licenses>
     <scm>
         <connection>scm:git:git@github.com:tinkerpop/gremlin.git</connection>
         <developerConnection>scm:git:git@github.com:tinkerpop/gremlin.git</developerConnection>


### PR DESCRIPTION
I see there has been discussion in the past concerning deploying TinkerPop artifacts to the Maven central repository. The easiest way to do this seems to be to use Sonatype's free OSS service. The required steps are laid out in their Confluence page here:

https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide

I believe this patch meets all their requirements with the possible exception that contributor entries in the pom (or at least some of them) may need to be changed to developer entries. The changes are minor--add scm and license info and add Sonatype's parent pom to configure distributionManagement to use their OSS Nexus instance (instead of TinkerPop's own distributionManagement, which is removed).

The only thing remaining is for a TinkerPop committer to create a Sonatype Jira ticket containing some information laid out in the Usage Guide and to push the artifacts once approved!
