### PR TITLE
Explicit NPE throwing

### DIFF
--- a/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/GremlinPipeline.java
+++ b/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/GremlinPipeline.java
@@ -87,12 +87,17 @@ public class GremlinPipeline<S, E> extends Pipeline<S, E> implements GremlinFlue
 
     private boolean doQueryOptimization = true;
 
+    private static final String NPE_NULL_START = "<null> as start is not allowed";
+
     public GremlinPipeline() {
         super();
     }
 
     public GremlinPipeline(final Object starts, final boolean doQueryOptimization) {
         super(new StartPipe(starts));
+        if (starts == null) {
+            throw new NullPointerException(NPE_NULL_START);
+        }
         this.doQueryOptimization = doQueryOptimization;
         FluentUtility.setStarts(this, starts);
     }
@@ -1057,6 +1062,9 @@ public class GremlinPipeline<S, E> extends Pipeline<S, E> implements GremlinFlue
      * @return the extended Pipeline
      */
     public GremlinPipeline<S, S> start(final S object) {
+        if (object == null) {
+            throw new NullPointerException(NPE_NULL_START);
+        }
         this.add(new StartPipe<S>(object));
         FluentUtility.setStarts(this, object);
         return (GremlinPipeline<S, S>) this;

--- a/gremlin-java/src/test/java/com/tinkerpop/gremlin/java/GremlinFluentUtilityTest.java
+++ b/gremlin-java/src/test/java/com/tinkerpop/gremlin/java/GremlinFluentUtilityTest.java
@@ -13,11 +13,11 @@ import com.tinkerpop.gremlin.pipes.transform.QueryPipe;
 import com.tinkerpop.pipes.filter.FilterPipe;
 import com.tinkerpop.pipes.filter.RangeFilterPipe;
 import com.tinkerpop.pipes.sideeffect.SideEffectFunctionPipe;
-import com.tinkerpop.pipes.sideeffect.SideEffectPipe;
 import com.tinkerpop.pipes.transform.IdentityPipe;
 import com.tinkerpop.pipes.util.StartPipe;
 import junit.framework.TestCase;
-import org.w3c.dom.ranges.Range;
+
+import java.util.Iterator;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -121,7 +121,7 @@ public class GremlinFluentUtilityTest extends TestCase {
         assertTrue(pipeline.get(4) instanceof IdentityPipe);
         assertTrue(pipeline.get(5) instanceof BothVerticesPipe);
 
-        pipeline = new GremlinPipeline(graph.getVertex(1)).outE("knows", "created").has("weight", 0.5)._().interval("since", 10, 2).range(1,10).bothV();
+        pipeline = new GremlinPipeline(graph.getVertex(1)).outE("knows", "created").has("weight", 0.5)._().interval("since", 10, 2).range(1, 10).bothV();
         //System.out.println(pipeline);
         assertEquals(pipeline.size(), 7);
         assertTrue(pipeline.get(0) instanceof StartPipe);
@@ -164,7 +164,7 @@ public class GremlinFluentUtilityTest extends TestCase {
 
 
         // TEST OPTIMIZE(BOOLEAN) PARAMETERIZATION
-        pipeline = new GremlinPipeline(graph.getVertex(1)).optimize(false).outE("knows").has("weight",0.5).inV();
+        pipeline = new GremlinPipeline(graph.getVertex(1)).optimize(false).outE("knows").has("weight", 0.5).inV();
         //System.out.println(pipeline);
         assertEquals(pipeline.size(), 4);
         assertTrue(pipeline.get(0) instanceof StartPipe);
@@ -172,13 +172,39 @@ public class GremlinFluentUtilityTest extends TestCase {
         assertTrue(pipeline.get(2) instanceof PropertyFilterPipe);
         assertTrue(pipeline.get(3) instanceof InVertexPipe);
 
-        pipeline = new GremlinPipeline(graph.getVertex(1)).optimize(true).outE("knows").has("weight",0.5).inV();
+        pipeline = new GremlinPipeline(graph.getVertex(1)).optimize(true).outE("knows").has("weight", 0.5).inV();
         //System.out.println(pipeline);
         assertEquals(pipeline.size(), 4);
         assertTrue(pipeline.get(0) instanceof StartPipe);
         assertTrue(pipeline.get(1) instanceof QueryPipe);
         assertTrue(pipeline.get(2) instanceof IdentityPipe);
         assertTrue(pipeline.get(3) instanceof InVertexPipe);
+    }
+
+    public void testNullStart() {
+        GremlinPipeline pipeline;
+        try {
+            pipeline = new GremlinPipeline(null);
+        } catch (NullPointerException e) {
+        }
+        try {
+            pipeline = new GremlinPipeline(null, false);
+            fail();
+        } catch (NullPointerException e) {
+        }
+        try {
+            pipeline = new GremlinPipeline();
+            pipeline.start(null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+        try {
+            pipeline = new GremlinPipeline();
+            pipeline.setStarts((Iterator) null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+
     }
 
 }


### PR DESCRIPTION
In case of 

graph.getVertex(keyword1.getId() == null

new GremlinPipeline(graph.getVertex(keyword1.getId()))
.out("IS_IN")
.dedup().in("IS_IN")
.has("keyword", keyword2.getKeyword()).count();

will throw NPE too deeply inside pipes...

I have spend about an hour to manage such simple error.
So, I think it is better to throw NPE explicit .
