### PR TITLE
Gremlin query results toString

### DIFF
--- a/gremlin-groovy/src/main/java/com/tinkerpop/gremlin/groovy/console/ResultHookClosure.java
+++ b/gremlin-groovy/src/main/java/com/tinkerpop/gremlin/groovy/console/ResultHookClosure.java
@@ -1,11 +1,9 @@
 package com.tinkerpop.gremlin.groovy.console;
 
+import com.tinkerpop.gremlin.java.GremlinToStringPipe;
 import com.tinkerpop.pipes.util.iterators.SingleIterator;
 import groovy.lang.Closure;
 import org.codehaus.groovy.tools.shell.IO;
-
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -22,21 +20,11 @@ public class ResultHookClosure extends Closure {
 
     public Object call(final Object[] args) {
         final Object result = args[0];
-        final Iterator itty;
-        if (result instanceof Iterator) {
-            itty = (Iterator) result;
-        } else if (result instanceof Iterable) {
-            itty = ((Iterable) result).iterator();
-        } else if (result instanceof Object[]) {
-            itty = new ArrayIterator((Object[]) result);
-        } else if (result instanceof Map) {
-            itty = ((Map) result).entrySet().iterator();
-        } else {
-            itty = new SingleIterator<Object>(result);
-        }
+        GremlinToStringPipe toStringPipe = new GremlinToStringPipe();
+        toStringPipe.setStarts(new SingleIterator<Object>(result));
 
-        while (itty.hasNext()) {
-            this.io.out.println(this.resultPrompt + itty.next());
+        while (toStringPipe.hasNext()) {
+            this.io.out.println(this.resultPrompt + toStringPipe.next());
         }
 
         return null;

--- a/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/ArrayIterator.java
+++ b/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/ArrayIterator.java
@@ -1,4 +1,4 @@
-package com.tinkerpop.gremlin.groovy.console;
+package com.tinkerpop.gremlin.java;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/GremlinToStringPipe.java
+++ b/gremlin-java/src/main/java/com/tinkerpop/gremlin/java/GremlinToStringPipe.java
@@ -1,0 +1,47 @@
+package com.tinkerpop.gremlin.java;
+
+import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.transform.TransformPipe;
+import com.tinkerpop.pipes.util.PipeHelper;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Date: 2013/06/12
+ * Time: 8:24 PM
+ */
+public class GremlinToStringPipe<S> extends AbstractPipe<S, String> implements TransformPipe<S, String> {
+
+    private Iterator<Object> tempIterator = PipeHelper.emptyIterator();
+
+    @Override
+    protected String processNextStart() throws NoSuchElementException {
+        while (true) {
+            if (this.tempIterator.hasNext()) {
+                return this.tempIterator.next().toString();
+            } else {
+                final Object result = this.starts.next();
+                if (result instanceof Iterator) {
+                    tempIterator = (Iterator) result;
+                } else if (result instanceof Iterable) {
+                    tempIterator = ((Iterable) result).iterator();
+                } else if (result instanceof Object[]) {
+                    tempIterator = new ArrayIterator((Object[]) result);
+                } else if (result instanceof Map) {
+                    tempIterator = ((Map) result).entrySet().iterator();
+                } else {
+                    return result.toString();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void reset() {
+        this.tempIterator = PipeHelper.emptyIterator();
+        super.reset();
+    }
+
+}


### PR DESCRIPTION
From java there is a need to display the results of a query as a string.
This is already happening via the groovy console.
This pull request adds a GremlinToStringPipe that can be used in the console and from java to transform the results.
