### PR TITLE
add ability to specify a script base class to the GremlinGroovyScriptEngine

### DIFF
--- a/gremlin-groovy/src/main/java/com/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
+++ b/gremlin-groovy/src/main/java/com/tinkerpop/gremlin/groovy/jsr223/GremlinGroovyScriptEngine.java
@@ -66,9 +66,20 @@ public class GremlinGroovyScriptEngine extends GroovyScriptEngineImpl {
         this.cacheResetSize = cacheResetSize;
     }
 
+    public GremlinGroovyScriptEngine(String scripBaseClass) {
+        this(scripBaseClass, new DefaultImportCustomizerProvider());
+    }
+
     public GremlinGroovyScriptEngine(final ImportCustomizerProvider importCustomizerProvider) {
+        this(null, importCustomizerProvider);
+    }
+
+    public GremlinGroovyScriptEngine(String scriptBaseClass, final ImportCustomizerProvider importCustomizerProvider) {
         Gremlin.load();
         final CompilerConfiguration conf = new CompilerConfiguration();
+        if (scriptBaseClass != null) {
+            conf.setScriptBaseClass(scriptBaseClass);
+        }
         conf.addCompilationCustomizers(importCustomizerProvider.getImportCustomizer());
         this.loader = new GroovyClassLoader(getParentLoader(), conf);
     }

--- a/gremlin-groovy/src/test/groovy/com/tinkerpop/gremlin/groovy/basescript/GremlinGroovyPipelineInterceptor.groovy
+++ b/gremlin-groovy/src/test/groovy/com/tinkerpop/gremlin/groovy/basescript/GremlinGroovyPipelineInterceptor.groovy
@@ -1,0 +1,27 @@
+package com.tinkerpop.gremlin.groovy.basescript
+
+/**
+ * Created by pieter on 2014/04/21.
+ */
+class GremlinGroovyPipelineInterceptor implements Interceptor {
+
+    @Override
+    Object beforeInvoke(Object object, String methodName, Object[] arguments) {
+        null
+    }
+
+    @Override
+    Object afterInvoke(Object object, String methodName, Object[] arguments, Object result) {
+        if (methodName == 'V') {
+            return result.hasNot('deleted');
+        } else {
+            return result
+        }
+    }
+
+    @Override
+    boolean doInvoke() {
+        return true
+    }
+
+}

--- a/gremlin-groovy/src/test/groovy/com/tinkerpop/gremlin/groovy/basescript/GremlinGroovyScriptBaseClassForTest.groovy
+++ b/gremlin-groovy/src/test/groovy/com/tinkerpop/gremlin/groovy/basescript/GremlinGroovyScriptBaseClassForTest.groovy
@@ -1,0 +1,15 @@
+package com.tinkerpop.gremlin.groovy.basescript
+
+/**
+ * @author Pieter Martin
+ */
+abstract class GremlinGroovyScriptBaseClassForTest extends Script {
+
+    def useInterceptor= { Class theClass, Class theInterceptor, Closure theCode->
+        def proxy= ProxyMetaClass.getInstance( theClass )
+        def interceptor= theInterceptor.newInstance()
+        proxy.interceptor= interceptor
+        proxy.use( theCode )
+    }
+
+}


### PR DESCRIPTION
The ability to use a script base class is usefull to make generic groovy available to the script engine.
